### PR TITLE
Add support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: php
 php:
-- 7.1
-- 7.2
-- 7.3
-- 7.4
+    - 7.3
+    - 7.4
+    - 8.0
 env:
-  matrix:
-  - COMPOSER_FLAGS="--prefer-lowest"
-  - COMPOSER_FLAGS=""
+    matrix:
+        - COMPOSER_FLAGS="--prefer-lowest"
+        - COMPOSER_FLAGS=""
 before_script:
-- travis_retry composer self-update
-- travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+    - travis_retry composer self-update
+    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 script:
-- vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
-- vendor/bin/phpcs --standard=PSR2 ./src
+    - vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
+    - vendor/bin/phpcs --standard=PSR2 ./src
 after_script:
-- php vendor/bin/coveralls -v
+    - php vendor/bin/coveralls -v
 notifications:
-  slack:
-    rooms:
-      secure: WWZmxESfUhOm/Sh3/XyL9Qd7iZ55Is0I1zhPivnAaN0G8j/nnLC4ihHj5lB8JzjVne0umsbJuJq8j2rTgEs8eLy78tlGQ3Vcxb7aNlAFg+Af790uoV5i2HscMBxBbjUPREK13AzgxuintKNpVG8S++YSe6qM1mIO938CtD+U8Nfbk0JtSV7j7S3aVQVaF4pprkmNOF5Sl2JZ19DoN0EK/r8iXOhwu+udw+CGavBx3gdgRO73mxuHdcGn/EP1kAwkhIIQeas7wYzuu5H29inzQKBsM2eS6vveaUuWSKEa6pXj6YkHmWnWov1+y/Q8XLis0JJT7759b7nKNC1mUFF0PeRGwzWvzYNZ1+WmSap2rB9gSj6l5Q+DAuNY/ULE3np8uWattayjz8KOgwL9XzDtMXjajaTFwkfjLsJmFtSj7dpCOcae8+CZ2pcy2sGxEdP8iKTrLeL+pMcbHNGF3Ez/z4HqoEqIZ856Bj9qu1lvmTZRTAieiBw9aAw5wCzZzLzc+eu41bilQM8GWDHRYNyPZEBqtfNpXhg55FfRY8hIFbax9qTZOewF4cILsRJfdhPNNrnvj4B3sbJEhenSQnb+X0N6ii/iHVgfPFbPQH6EUublfM+cNy3AqEqAR8hccdaM+aFTPGlY8OiRM9Q53i2WIppxqhVA3741dUDXk+JDvFg=
+    slack:
+        rooms:
+            secure: WWZmxESfUhOm/Sh3/XyL9Qd7iZ55Is0I1zhPivnAaN0G8j/nnLC4ihHj5lB8JzjVne0umsbJuJq8j2rTgEs8eLy78tlGQ3Vcxb7aNlAFg+Af790uoV5i2HscMBxBbjUPREK13AzgxuintKNpVG8S++YSe6qM1mIO938CtD+U8Nfbk0JtSV7j7S3aVQVaF4pprkmNOF5Sl2JZ19DoN0EK/r8iXOhwu+udw+CGavBx3gdgRO73mxuHdcGn/EP1kAwkhIIQeas7wYzuu5H29inzQKBsM2eS6vveaUuWSKEa6pXj6YkHmWnWov1+y/Q8XLis0JJT7759b7nKNC1mUFF0PeRGwzWvzYNZ1+WmSap2rB9gSj6l5Q+DAuNY/ULE3np8uWattayjz8KOgwL9XzDtMXjajaTFwkfjLsJmFtSj7dpCOcae8+CZ2pcy2sGxEdP8iKTrLeL+pMcbHNGF3Ez/z4HqoEqIZ856Bj9qu1lvmTZRTAieiBw9aAw5wCzZzLzc+eu41bilQM8GWDHRYNyPZEBqtfNpXhg55FfRY8hIFbax9qTZOewF4cILsRJfdhPNNrnvj4B3sbJEhenSQnb+X0N6ii/iHVgfPFbPQH6EUublfM+cNy3AqEqAR8hccdaM+aFTPGlY8OiRM9Q53i2WIppxqhVA3741dUDXk+JDvFg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     matrix:
         - COMPOSER_FLAGS="--prefer-lowest"
         - COMPOSER_FLAGS=""
+    global:
+        - XDEBUG_MODE=coverage
 before_script:
     - travis_retry composer self-update
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
         - XDEBUG_MODE=coverage
 before_script:
     - travis_retry composer self-update
-    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source --no-cache
 script:
     - vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
     - vendor/bin/phpcs --standard=PSR2 ./src
 after_script:
-    - php vendor/bin/coveralls -v
+    - php vendor/bin/php-coveralls -v
 notifications:
     slack:
         rooms:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+v5.0.0
+- Add support for PHP 8
+- Change function signature on `ResponseFactory::create()` so that optional parameters come after non-optional
+
 v4.4.0
 - Switch from the deprecated `zendframework/zend-diactoros` to `laminas/laminas-diactoros`
 - Increase minimum PHP version to 7.1

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpunit/phpunit": "^8.0",
         "php-coveralls/php-coveralls": "^1.0",
         "mockery/mockery": "^1.3.1",
-        "squizlabs/php_codesniffer": "^3.3.1"
+        "squizlabs/php_codesniffer": "^3.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "laminas/laminas-diactoros": "^2.4"
     },
     "require-dev": {
-        "php-di/php-di": "^6.0.0",
+        "php-di/php-di": "^6.3.4",
         "phpunit/phpunit": "^8.0",
         "php-coveralls/php-coveralls": "^1.0",
-        "mockery/mockery": "^1.3.1",
+        "mockery/mockery": "^1.4.3",
         "squizlabs/php_codesniffer": "^3.6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.3||^8.0",
         "altorouter/altorouter": "^1.1",
         "mindplay/middleman": "^3.0.3",
         "php-di/invoker": "^2.0.0",
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "php-di/php-di": "^6.0.0",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^8.0",
         "php-coveralls/php-coveralls": "^1.0",
         "mockery/mockery": "^1.3.1",
         "squizlabs/php_codesniffer": "^3.3.1"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.3||^8.0",
         "altorouter/altorouter": "^1.1",
         "mindplay/middleman": "^3.0.3",
-        "php-di/invoker": "^2.0.0",
+        "php-di/invoker": "^2.3.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "php-di/php-di": "^6.3.4",
         "phpunit/phpunit": "^8.0",
-        "php-coveralls/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^2.4",
         "mockery/mockery": "^1.4.3",
         "squizlabs/php_codesniffer": "^3.6.0"
     },

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -1,7 +1,9 @@
 <?php
+
 /**
  * @phpcs:disable PEAR.Functions.ValidDefaultValue
  */
+
 namespace Rareloop\Router;
 
 use Psr\Http\Message\RequestInterface;
@@ -12,7 +14,7 @@ use Zend\Diactoros\Response\HtmlResponse;
 
 class ResponseFactory
 {
-    public static function create($response = '', RequestInterface $request)
+    public static function create(RequestInterface $request, $response = '')
     {
         if (empty($response)) {
             return new EmptyResponse();

--- a/src/Route.php
+++ b/src/Route.php
@@ -56,7 +56,7 @@ class Route
         $this->routeAction = new RouteAction($action, $this->invoker);
     }
 
-    public function handle(ServerRequest $request, RouteParams $params) : ResponseInterface
+    public function handle(ServerRequest $request, RouteParams $params): ResponseInterface
     {
         // Get all the middleware registered for this route
         $middlewares = $this->gatherMiddleware();
@@ -65,7 +65,7 @@ class Route
         $middlewares[] = function ($request) use ($params) {
             $output = $this->routeAction->invoke($request, $params);
 
-            return ResponseFactory::create($output, $request);
+            return ResponseFactory::create($request, $output);
         };
 
         // Create and process the dispatcher
@@ -80,7 +80,7 @@ class Route
         return $dispatcher->dispatch($request);
     }
 
-    private function gatherMiddleware() : array
+    private function gatherMiddleware(): array
     {
         return array_merge([], $this->middleware, $this->routeAction->getMiddleware());
     }

--- a/src/TypeHintRequestResolver.php
+++ b/src/TypeHintRequestResolver.php
@@ -2,10 +2,11 @@
 
 namespace Rareloop\Router;
 
-use Invoker\ParameterResolver\ParameterResolver;
-use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
 use ReflectionFunctionAbstract;
 use Zend\Diactoros\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
+use Invoker\ParameterResolver\ParameterResolver;
 
 class TypeHintRequestResolver implements ParameterResolver
 {
@@ -27,7 +28,9 @@ class TypeHintRequestResolver implements ParameterResolver
         }
 
         foreach ($parameters as $index => $parameter) {
-            $parameterClass = $parameter->getClass();
+            $parameterClass = $parameter->getType() && !$parameter->getType()->isBuiltin()
+                ? new ReflectionClass($parameter->getType()->getName())
+                : null;
 
             if (!$parameterClass) {
                 continue;

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -15,7 +15,7 @@ class ResponseFactoryTest extends TestCase
 {
     use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -63,7 +63,7 @@ class ResponseFactoryTest extends TestCase
 
 class ResponsableObject implements Responsable
 {
-    public function toResponse(RequestInterface $request) : ResponseInterface
+    public function toResponse(RequestInterface $request): ResponseInterface
     {
         return new TextResponse('testing123');
     }

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -27,13 +27,13 @@ class ResponseFactoryTest extends TestCase
     {
         $response = new TextResponse('Testing', 200);
 
-        $this->assertSame($response, ResponseFactory::create($response, $this->request));
+        $this->assertSame($response, ResponseFactory::create($this->request, $response));
     }
 
     /** @test */
     public function when_passed_a_non_response_instance_a_response_object_is_returned()
     {
-        $response = ResponseFactory::create('Testing', $this->request);
+        $response = ResponseFactory::create($this->request, 'Testing');
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertSame('Testing', $response->getBody()->getContents());
@@ -42,7 +42,7 @@ class ResponseFactoryTest extends TestCase
     /** @test */
     public function when_nothing_is_passed_an_empty_response_object_is_returned()
     {
-        $response = ResponseFactory::create(null, $this->request);
+        $response = ResponseFactory::create($this->request);
 
         $this->assertInstanceOf(EmptyResponse::class, $response);
     }
@@ -54,7 +54,7 @@ class ResponseFactoryTest extends TestCase
         $object = \Mockery::mock(ResponsableObject::class);
         $object->shouldReceive('toResponse')->with($this->request)->once()->andReturn($textResponse);
 
-        $response = ResponseFactory::create($object, $this->request);
+        $response = ResponseFactory::create($this->request, $object);
 
         $this->assertInstanceOf(TextResponse::class, $response);
         $this->assertSame('testing123', $response->getBody()->getContents());


### PR DESCRIPTION
This introduces a breaking change in the function signature of `RequestFactory::create()`.

It also removes support for PHP 7.1 & 7.2 which are now both EOL.