### PR TITLE
Update Laminas\Diactoros namespace

### DIFF
--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -9,8 +9,8 @@ namespace Rareloop\Router;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Rareloop\Router\Responsable;
-use Zend\Diactoros\Response\EmptyResponse;
-use Zend\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\HtmlResponse;
 
 class ResponseFactory
 {

--- a/src/Route.php
+++ b/src/Route.php
@@ -11,9 +11,9 @@ use Rareloop\Router\Exceptions\RouteNameRedefinedException;
 use Rareloop\Router\Invoker;
 use Rareloop\Router\ProvidesMiddleware;
 use Spatie\Macroable\Macroable;
-use Zend\Diactoros\Response\EmptyResponse;
-use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\ServerRequest;
 use mindplay\middleman\Dispatcher;
 
 class Route

--- a/src/Router.php
+++ b/src/Router.php
@@ -16,7 +16,7 @@ use Rareloop\Router\RouteGroup;
 use Rareloop\Router\RouteParams;
 use Rareloop\Router\VerbShortcutsTrait;
 use Spatie\Macroable\Macroable;
-use Zend\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\Response\TextResponse;
 use \AltoRouter;
 use mindplay\middleman\Dispatcher;
 

--- a/src/TypeHintRequestResolver.php
+++ b/src/TypeHintRequestResolver.php
@@ -4,7 +4,7 @@ namespace Rareloop\Router;
 
 use ReflectionClass;
 use ReflectionFunctionAbstract;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
 use Invoker\ParameterResolver\ParameterResolver;
 

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -11,7 +11,7 @@ use Rareloop\Router\MiddlewareResolver;
 use Rareloop\Router\Router;
 use Rareloop\Router\Test\Controllers\MiddlewareProvidingController;
 use Rareloop\Router\Test\Middleware\AddHeaderMiddleware;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class ControllerTest extends TestCase
 {

--- a/tests/Middleware/AddHeaderMiddleware.php
+++ b/tests/Middleware/AddHeaderMiddleware.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class AddHeaderMiddleware implements MiddlewareInterface
 {

--- a/tests/Requests/TestRequest.php
+++ b/tests/Requests/TestRequest.php
@@ -2,7 +2,7 @@
 
 namespace Rareloop\Router\Test\Requests;
 
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class TestRequest extends ServerRequest
 {

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -7,9 +7,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Rareloop\Router\Responsable;
 use Rareloop\Router\ResponseFactory;
-use Zend\Diactoros\Response\EmptyResponse;
-use Zend\Diactoros\Response\TextResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 
 class ResponseFactoryTest extends TestCase
 {

--- a/tests/RouterDITest.php
+++ b/tests/RouterDITest.php
@@ -9,7 +9,7 @@ use Rareloop\Router\Router;
 use Rareloop\Router\Test\Controllers\TestController;
 use Rareloop\Router\Test\Requests\TestRequest;
 use Rareloop\Router\Test\Services\TestService;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class RouterDITest extends TestCase
 {

--- a/tests/RouterMiddlewareTest.php
+++ b/tests/RouterMiddlewareTest.php
@@ -13,7 +13,7 @@ use Rareloop\Router\RouteGroup;
 use Rareloop\Router\Router;
 use Rareloop\Router\Test\Controllers\MiddlewareProvidingController;
 use Rareloop\Router\Test\Middleware\AddHeaderMiddleware;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class RouterMiddlewareTest extends TestCase
 {

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -15,9 +15,9 @@ use Rareloop\Router\Route;
 use Rareloop\Router\RouteGroup;
 use Rareloop\Router\RouteParams;
 use Rareloop\Router\Router;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\Response\TextResponse;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 
 class RouterTest extends TestCase
 {

--- a/tests/TypeHintRequestResolverTest.php
+++ b/tests/TypeHintRequestResolverTest.php
@@ -4,7 +4,7 @@ namespace Rareloop\Router\Test;
 
 use PHPUnit\Framework\TestCase;
 use Rareloop\Router\TypeHintRequestResolver;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class TypeHintRequestResolverTest extends TestCase
 {


### PR DESCRIPTION
Latest Laminas/Diactoros (2.7) broke router type hinting resolver. See: https://github.com/laminas/laminas-diactoros/compare/2.6.0...2.7.0