### PR TITLE
Add tests to ensure AltoRouter can match against root paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "altorouter/altorouter": "^2.0.1",
+        "altorouter/altorouter": "^2.0.2",
         "mindplay/middleman": "^3.0.3",
         "php-di/invoker": "^2.3.0",
         "psr/container": "^1.0",

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -160,6 +160,21 @@ class RouterTest extends TestCase
     }
 
     /** @test */
+    public function mathcing_root_path_does_not_trigger_error()
+    {
+        $request = new ServerRequest([], [], '/', 'GET');
+        $router = new Router;
+        $count = 0;
+
+        $route = $router->get('/test/123', function () use (&$count) {
+            $count++;
+        });
+        $response = $router->match($request);
+
+        $this->assertSame(0, $count);
+    }
+
+    /** @test */
     public function match_returns_a_response_object()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -160,7 +160,7 @@ class RouterTest extends TestCase
     }
 
     /** @test */
-    public function mathcing_root_path_does_not_trigger_error()
+    public function matching_root_path_does_not_trigger_error()
     {
         $request = new ServerRequest([], [], '/', 'GET');
         $router = new Router;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -175,6 +175,21 @@ class RouterTest extends TestCase
     }
 
     /** @test */
+    public function can_match_a_route_for_root_path()
+    {
+        $request = new ServerRequest([], [], '/', 'GET');
+        $router = new Router;
+        $count = 0;
+
+        $route = $router->get('/', function () use (&$count) {
+            $count++;
+        });
+        $response = $router->match($request);
+
+        $this->assertSame(1, $count);
+    }
+
+    /** @test */
     public function match_returns_a_response_object()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');


### PR DESCRIPTION
Waiting on AltoRouter to do a release including https://github.com/dannyvankooten/AltoRouter/pull/247

Issue: https://github.com/dannyvankooten/AltoRouter/issues/258

- [x] Add tests
- [x] Test on updated AltoRouter release
- [x] Increase minimum AltoRouter version in `composer.json`