### PR TITLE
Allow full stops in route parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/src/Router.php
+++ b/src/Router.php
@@ -132,6 +132,9 @@ class Router implements Routable
 
         $this->altoRouter = new AltoRouter();
         $this->altoRouter->setBasePath($this->basePath);
+        $this->altoRouter->addMatchTypes([
+             '' => '[^/]++',
+        ]);
         $this->altoRoutesCreated = true;
 
         foreach ($this->routes as $route) {

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -385,6 +385,23 @@ class RouterTest extends TestCase
     }
 
     /** @test */
+    public function params_may_contain_full_stops()
+    {
+        $request = new ServerRequest([], [], '/posts/a.b.c', 'GET');
+        $router = new Router;
+
+        $route = $router->get('/posts/{postId}', function ($params) use (&$count) {
+            $count++;
+
+            $this->assertInstanceOf(RouteParams::class, $params);
+            $this->assertSame('a.b.c', $params->postId);
+        });
+        $router->match($request);
+
+        $this->assertSame(1, $count);
+    }
+
+    /** @test */
     public function params_are_parsed_and_passed_into_callback_function_when_surrounded_by_whitespace()
     {
         $request = new ServerRequest([], [], '/posts/123/comments/abc', 'GET');


### PR DESCRIPTION
Uses the suggested fix in https://github.com/dannyvankooten/AltoRouter/issues/221#issuecomment-424599922 in order to allow the router to parse param values with dots.

We will need to consider the implications of this, as the comment mentions that it ignores full stops so that you can ignore file extensions in URLs. This MR causes some behaviour changes:

**Previously**

`/route/{id}` with `route/file.txt` would not match at all.

**Now**

`/route/{id}` with `route/file.txt` would match, and `id` would be mapped to `file.txt`.