### PR TITLE
Implement support for a default ParameterResolver

### DIFF
--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -26,7 +26,7 @@ class Invoker extends DIInvoker
         $resolver->prependResolver($this->requestResolver);
     }
 
-    public function setRequest(ServerRequestInterface $request): Invoker
+    public function setRequest(ServerRequestInterface $request) : Invoker
     {
         $this->requestResolver->setRequest($request);
 

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -4,6 +4,7 @@ namespace Rareloop\Router;
 
 use Invoker\Invoker as DIInvoker;
 use Invoker\ParameterResolver\Container\TypeHintContainerResolver;
+use Invoker\ParameterResolver\ParameterResolver;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -11,9 +12,9 @@ class Invoker extends DIInvoker
 {
     private $requestResolver;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, ?ParameterResolver $parameterResolver = null)
     {
-        parent::__construct(null, $container);
+        parent::__construct($parameterResolver, $container);
 
         $resolver = $this->getParameterResolver();
 
@@ -25,7 +26,7 @@ class Invoker extends DIInvoker
         $resolver->prependResolver($this->requestResolver);
     }
 
-    public function setRequest(ServerRequestInterface $request) : Invoker
+    public function setRequest(ServerRequestInterface $request): Invoker
     {
         $this->requestResolver->setRequest($request);
 


### PR DESCRIPTION
Augments the `Invoker` implementation to support a default `ParameterResolver`. This allows easy extension for additional resolvers in downstream projects.

Critically, this is backwards compatible, and the existing resolvers are still _prepended_ and thus take priority.